### PR TITLE
Support for a custom prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,40 @@ You can also run `--help` to get the list of available `commands`, `arguments` a
 | `--issue-number`         | The GitHub issue number.                                                           |
 | `--token`                | (Optional) The GitHub API token. It is only required for private repos.            |
 
-**Example:**
+### Common AIProvider Parameters
+
+There are some common parameters that can be used with all AI providers, namely, `--ai-model` and `--ai-prompt`.
+The following sections describe these parameters.
+
+#### AiModel
+
+The `--ai-model` parameter is used to specify the model to be used by the AI provider.
+You have to check the documentation of the AI provider to know which models are available.
+
+#### AiPrompt
+
+The `--ai-prompt` parameter is used to specify the prompt to be used by the AI provider.
+The prompt make use of Go's [`text/template` package](https://pkg.go.dev/text/template) to render the prompt.
+The prompt will receive a `struct` in form of `Comments`, with the following structure:
+```go
+type Comments []Comment
+
+type Comment struct {
+    Author string
+    Body   string
+}
+```
+You could, for example, inject the following prompt:
+```go
+var myAwesomeTemplate = `
+Please summarize the following discussions between different Authors.
+{{ range $comment := . }}
+Author {{ $comment.Author }} said: {{ $comment.Body }}
+{{ end }}
+`
+```
+
+## Example
 
 ```bash 
 go run cmd/summaraizer/summaraizer.go ollama --url http://localhost:11434 --ai-model llama3 --owner golang --repo go --issue-number 66960

--- a/cmd/summaraizer/summaraizer.go
+++ b/cmd/summaraizer/summaraizer.go
@@ -33,10 +33,12 @@ var ollamaCmd = &cobra.Command{
 		}
 
 		aiModel, _ := cmd.Flags().GetString("ai-model")
+		aiPrompt, _ := cmd.Flags().GetString("ai-prompt")
 		url, _ := cmd.Flags().GetString("url")
 		provider := &provider.Ollama{
 			Common: provider.Common{
-				Model: aiModel,
+				Model:  aiModel,
+				Prompt: aiPrompt,
 			},
 			Url: url,
 		}
@@ -67,10 +69,12 @@ var mistralCmd = &cobra.Command{
 		}
 
 		aiModel, _ := cmd.Flags().GetString("ai-model")
+		aiPrompt, _ := cmd.Flags().GetString("ai-prompt")
 		apiToken, _ := cmd.Flags().GetString("api-token")
 		provider := &provider.Mistral{
 			Common: provider.Common{
-				Model: aiModel,
+				Model:  aiModel,
+				Prompt: aiPrompt,
 			},
 			ApiToken: apiToken,
 		}
@@ -101,10 +105,12 @@ var openaiCmd = &cobra.Command{
 		}
 
 		aiModel, _ := cmd.Flags().GetString("ai-model")
+		aiPrompt, _ := cmd.Flags().GetString("ai-prompt")
 		apiToken, _ := cmd.Flags().GetString("api-token")
 		provider := &provider.OpenAi{
 			Common: provider.Common{
-				Model: aiModel,
+				Model:  aiModel,
+				Prompt: aiPrompt,
 			},
 			ApiToken: apiToken,
 		}
@@ -127,16 +133,16 @@ func main() {
 	rootCmd.MarkPersistentFlagRequired("repo")
 	rootCmd.MarkPersistentFlagRequired("issue-number")
 
-	ollamaCmd.PersistentFlags().String("ai-model", "mistral:7b", "AI Model")
+	createDefaultAiFlags(ollamaCmd, "mistral:7b", defaultPromptTemplate)
 	ollamaCmd.PersistentFlags().String("url", "http://localhost:11434", "The URl where ollama is accessible")
 	rootCmd.AddCommand(ollamaCmd)
 
-	mistralCmd.PersistentFlags().String("ai-model", "mistral-small-latest", "AI Model")
+	createDefaultAiFlags(mistralCmd, "mistral:7b", defaultPromptTemplate)
 	mistralCmd.PersistentFlags().String("api-token", "", "The API Token for Mistral")
 	mistralCmd.MarkPersistentFlagRequired("api-token")
 	rootCmd.AddCommand(mistralCmd)
 
-	openaiCmd.PersistentFlags().String("ai-model", "gpt-3.5-turbo", "AI Model")
+	createDefaultAiFlags(openaiCmd, "gpt-3.5-turbo", defaultPromptTemplate)
 	openaiCmd.PersistentFlags().String("api-token", "", "The API Token for OpenAI")
 	openaiCmd.MarkPersistentFlagRequired("api-token")
 	rootCmd.AddCommand(openaiCmd)
@@ -146,3 +152,18 @@ func main() {
 		os.Exit(1)
 	}
 }
+
+func createDefaultAiFlags(cmd *cobra.Command, model string, prompt string) {
+	cmd.PersistentFlags().String("ai-model", model, "AI Model")
+	cmd.PersistentFlags().String("ai-prompt", prompt, "The prompt to use for the AI model")
+}
+
+var defaultPromptTemplate = `
+I give you a discussion and you give me a summary.
+Each comment of the discussion is wrapped in a <comment> tag.
+Your summary should not be longer than 1200 chars.
+Here is the discussion:
+{{ range $comment := . }}
+<comment>{{ $comment.Body }}</comment>
+{{end}}
+`

--- a/cmd/summaraizer/summaraizer.go
+++ b/cmd/summaraizer/summaraizer.go
@@ -35,8 +35,10 @@ var ollamaCmd = &cobra.Command{
 		aiModel, _ := cmd.Flags().GetString("ai-model")
 		url, _ := cmd.Flags().GetString("url")
 		provider := &provider.Ollama{
-			Model: aiModel,
-			Url:   url,
+			Common: provider.Common{
+				Model: aiModel,
+			},
+			Url: url,
 		}
 
 		summarization, err := summaraizer.Summarize(gitHubInput, provider)
@@ -67,7 +69,9 @@ var mistralCmd = &cobra.Command{
 		aiModel, _ := cmd.Flags().GetString("ai-model")
 		apiToken, _ := cmd.Flags().GetString("api-token")
 		provider := &provider.Mistral{
-			Model:    aiModel,
+			Common: provider.Common{
+				Model: aiModel,
+			},
 			ApiToken: apiToken,
 		}
 
@@ -99,7 +103,9 @@ var openaiCmd = &cobra.Command{
 		aiModel, _ := cmd.Flags().GetString("ai-model")
 		apiToken, _ := cmd.Flags().GetString("api-token")
 		provider := &provider.OpenAi{
-			Model:    aiModel,
+			Common: provider.Common{
+				Model: aiModel,
+			},
 			ApiToken: apiToken,
 		}
 

--- a/provider/common.go
+++ b/provider/common.go
@@ -1,6 +1,24 @@
 package provider
 
+import (
+	"bytes"
+	"text/template"
+
+	"github.com/ioki-mobility/summaraizer"
+)
+
 // Common is a generic struct that shares common fields between all AI providers.
 type Common struct {
-	Model string // The Ai model to use.
+	Model  string // The Ai model to use.
+	Prompt string // The prompt to use for the AI model.
+}
+
+func resolvePrompt(prompt string, comments summaraizer.Comments) (string, error) {
+	must := template.Must(template.New("resolvedPrompt").Parse(prompt))
+	var buf bytes.Buffer
+	err := must.Execute(&buf, comments)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
 }

--- a/provider/common.go
+++ b/provider/common.go
@@ -1,0 +1,6 @@
+package provider
+
+// Common is a generic struct that shares common fields between all AI providers.
+type Common struct {
+	Model string // The Ai model to use.
+}

--- a/provider/mistral.go
+++ b/provider/mistral.go
@@ -6,8 +6,9 @@ import (
 	"github.com/ioki-mobility/summaraizer"
 )
 
+// Mistral is a provider that uses the Mistral API as an AI provider.
 type Mistral struct {
-	Model    string
+	Common
 	ApiToken string
 }
 

--- a/provider/ollama.go
+++ b/provider/ollama.go
@@ -19,13 +19,14 @@ type Ollama struct {
 func (o *Ollama) Summarize(
 	comments summaraizer.Comments,
 ) (string, error) {
-	var commentsPrompt string
-	for _, comment := range comments {
-		commentsPrompt += fmt.Sprintf("<comment>%s</comment>", comment)
+	prompt, err := resolvePrompt(o.Common.Prompt, comments)
+	if err != nil {
+		return "", err
 	}
+
 	reqJson := make(map[string]any)
 	reqJson["model"] = o.Model
-	reqJson["prompt"] = "I give you a discussion and you give me a summary. Each comment of the discussion is wrapped in a <comment> tag. Your summary should not be longer than 1200 chars. Here is the discussion: " + commentsPrompt
+	reqJson["prompt"] = prompt
 	reqJson["stream"] = false
 	reqBodyBytes, err := json.Marshal(reqJson)
 	if err != nil {

--- a/provider/ollama.go
+++ b/provider/ollama.go
@@ -10,9 +10,10 @@ import (
 	"github.com/ioki-mobility/summaraizer"
 )
 
+// Ollama is a provider that uses Ollama as an AI provider.
 type Ollama struct {
-	Model string
-	Url   string
+	Common
+	Url string
 }
 
 func (o *Ollama) Summarize(

--- a/provider/openai.go
+++ b/provider/openai.go
@@ -6,8 +6,9 @@ import (
 	"github.com/ioki-mobility/summaraizer"
 )
 
+// OpenAi is a provider that uses OpenAI API as an AI provider.
 type OpenAi struct {
-	Model    string
+	Common
 	ApiToken string
 }
 

--- a/source/github.go
+++ b/source/github.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ioki-mobility/summaraizer"
 )
 
+// GitHub is a source that fetches comments from a GitHub issue or pull request.
 type GitHub struct {
 	Token       string
 	RepoOwner   string

--- a/summaraizer.go
+++ b/summaraizer.go
@@ -7,14 +7,17 @@ type Comment struct {
 	Body   string
 }
 
+// CommentSource is an interface that defines a source to fetch comments from.
 type CommentSource interface {
 	Fetch() (Comments, error)
 }
 
+// AiProvider is an interface that defines an AI provider to summarize comments.
 type AiProvider interface {
 	Summarize(comments Comments) (string, error)
 }
 
+// Summarize fetches comments from a source and summarizes them using an AI provider.
 func Summarize(source CommentSource, aiProvider AiProvider) (string, error) {
 	comments, err := source.Fetch()
 	if err != nil {


### PR DESCRIPTION
fixes #2 

* Also add some documentation to functions, structs, you name it
* Introduce `provider.Common` that shares fields for all AiProviders