### PR TITLE
Adjust CLI to support multiple sources

### DIFF
--- a/cmd/summaraizer/summaraizer.go
+++ b/cmd/summaraizer/summaraizer.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/ioki-mobility/summaraizer"
 	"github.com/ioki-mobility/summaraizer/provider"
@@ -10,142 +11,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var rootCmd = &cobra.Command{
-	Use:   "summaraizer",
-	Short: "Summarizes GitHub issue comments",
-	Long:  `A tool to summarize GitHub issue (or pull request) comments using AI.`,
-}
-
-var ollamaCmd = &cobra.Command{
-	Use:   "ollama",
-	Short: "Summarizes using Ollama AI",
-	Long:  `Summarizes using Ollama AI.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		token, _ := cmd.Flags().GetString("token")
-		owner, _ := cmd.Flags().GetString("owner")
-		repo, _ := cmd.Flags().GetString("repo")
-		issueNumber, _ := cmd.Flags().GetString("issue-number")
-		gitHubInput := &source.GitHub{
-			Token:       token,
-			RepoOwner:   owner,
-			RepoName:    repo,
-			IssueNumber: issueNumber,
-		}
-
-		aiModel, _ := cmd.Flags().GetString("ai-model")
-		aiPrompt, _ := cmd.Flags().GetString("ai-prompt")
-		url, _ := cmd.Flags().GetString("url")
-		provider := &provider.Ollama{
-			Common: provider.Common{
-				Model:  aiModel,
-				Prompt: aiPrompt,
-			},
-			Url: url,
-		}
-
-		summarization, err := summaraizer.Summarize(gitHubInput, provider)
-		if err != nil {
-			fmt.Println("Error:", err)
-			os.Exit(1)
-		}
-		fmt.Println(summarization)
-	},
-}
-
-var mistralCmd = &cobra.Command{
-	Use:   "mistral",
-	Short: "Summarizes using Mistral AI",
-	Long:  `Summarizes using Mistral AI.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		token, _ := cmd.Flags().GetString("token")
-		owner, _ := cmd.Flags().GetString("owner")
-		repo, _ := cmd.Flags().GetString("repo")
-		issueNumber, _ := cmd.Flags().GetString("issue-number")
-		gitHub := &source.GitHub{
-			Token:       token,
-			RepoOwner:   owner,
-			RepoName:    repo,
-			IssueNumber: issueNumber,
-		}
-
-		aiModel, _ := cmd.Flags().GetString("ai-model")
-		aiPrompt, _ := cmd.Flags().GetString("ai-prompt")
-		apiToken, _ := cmd.Flags().GetString("api-token")
-		provider := &provider.Mistral{
-			Common: provider.Common{
-				Model:  aiModel,
-				Prompt: aiPrompt,
-			},
-			ApiToken: apiToken,
-		}
-
-		summarization, err := summaraizer.Summarize(gitHub, provider)
-		if err != nil {
-			fmt.Println("Error:", err)
-			os.Exit(1)
-		}
-		fmt.Println(summarization)
-	},
-}
-
-var openaiCmd = &cobra.Command{
-	Use:   "openai",
-	Short: "Summarizes using OpenAI AI",
-	Long:  `Summarizes using OpenAI AI.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		token, _ := cmd.Flags().GetString("token")
-		owner, _ := cmd.Flags().GetString("owner")
-		repo, _ := cmd.Flags().GetString("repo")
-		issueNumber, _ := cmd.Flags().GetString("issue-number")
-		gitHubInput := &source.GitHub{
-			Token:       token,
-			RepoOwner:   owner,
-			RepoName:    repo,
-			IssueNumber: issueNumber,
-		}
-
-		aiModel, _ := cmd.Flags().GetString("ai-model")
-		aiPrompt, _ := cmd.Flags().GetString("ai-prompt")
-		apiToken, _ := cmd.Flags().GetString("api-token")
-		provider := &provider.OpenAi{
-			Common: provider.Common{
-				Model:  aiModel,
-				Prompt: aiPrompt,
-			},
-			ApiToken: apiToken,
-		}
-
-		summarization, err := summaraizer.Summarize(gitHubInput, provider)
-		if err != nil {
-			fmt.Println("Error:", err)
-			os.Exit(1)
-		}
-		fmt.Println(summarization)
-	},
-}
-
 func main() {
-	rootCmd.PersistentFlags().String("token", "", "GitHub Token (can be empty for public repositories)")
-	rootCmd.PersistentFlags().String("owner", "", "GitHub Repository Owner")
-	rootCmd.PersistentFlags().String("repo", "", "GitHub Repository Name")
-	rootCmd.PersistentFlags().String("issue-number", "", "GitHub Issue Number")
-	rootCmd.MarkPersistentFlagRequired("owner")
-	rootCmd.MarkPersistentFlagRequired("repo")
-	rootCmd.MarkPersistentFlagRequired("issue-number")
+	sourceCmds := []*cobra.Command{githubCmd(), redditCmd()}
+	for _, cmd := range sourceCmds {
+		cmd.AddCommand(ollamaCmd())
+		cmd.AddCommand(mistralCmd())
+		cmd.AddCommand(openaiCmd())
+	}
 
-	createDefaultAiFlags(ollamaCmd, "mistral:7b", defaultPromptTemplate)
-	ollamaCmd.PersistentFlags().String("url", "http://localhost:11434", "The URl where ollama is accessible")
-	rootCmd.AddCommand(ollamaCmd)
-
-	createDefaultAiFlags(mistralCmd, "mistral:7b", defaultPromptTemplate)
-	mistralCmd.PersistentFlags().String("api-token", "", "The API Token for Mistral")
-	mistralCmd.MarkPersistentFlagRequired("api-token")
-	rootCmd.AddCommand(mistralCmd)
-
-	createDefaultAiFlags(openaiCmd, "gpt-3.5-turbo", defaultPromptTemplate)
-	openaiCmd.PersistentFlags().String("api-token", "", "The API Token for OpenAI")
-	openaiCmd.MarkPersistentFlagRequired("api-token")
-	rootCmd.AddCommand(openaiCmd)
+	rootCmd.AddCommand(sourceCmds...)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
@@ -153,9 +27,228 @@ func main() {
 	}
 }
 
-func createDefaultAiFlags(cmd *cobra.Command, model string, prompt string) {
-	cmd.PersistentFlags().String("ai-model", model, "AI Model")
-	cmd.PersistentFlags().String("ai-prompt", prompt, "The prompt to use for the AI model")
+var rootCmd = &cobra.Command{
+	Use:   "summaraizer",
+	Short: "Summarizes comments",
+	Long:  "A tool to summarize comments from various sources using AI.",
+}
+
+type flag struct {
+	Name        string
+	Required    bool
+	Description string
+	Default     string
+}
+
+type gitHubFlag string
+
+const (
+	gitHubFlagIssue       gitHubFlag = "issue"
+	gitHubFlagSourceToken gitHubFlag = "source-token"
+)
+
+func githubCmd() *cobra.Command {
+	flags := []flag{
+		{
+			Name:        string(gitHubFlagIssue),
+			Required:    true,
+			Description: "The GitHub issue to summarize. Use the format owner/repo/issue_number.",
+		},
+		{
+			Name:        string(gitHubFlagSourceToken),
+			Required:    false,
+			Description: "The GitHub token to use as source",
+		},
+	}
+	return createDefaultCmd(
+		"github",
+		"Summarizes using GitHub as source",
+		"Summarizes using GitHub as source",
+		flags,
+	)
+}
+
+type redditFlag string
+
+const (
+	redditFlagPost redditFlag = "post"
+)
+
+func redditCmd() *cobra.Command {
+	flags := []flag{
+		{
+			Name:        string(redditFlagPost),
+			Required:    true,
+			Description: "The Reddit post to summarize. Use the URL path. Everything after reddit.com.",
+		},
+	}
+	return createDefaultCmd(
+		"reddit",
+		"Summarizes using Reddit as source",
+		"Summarizes using Reddit as source.",
+		flags,
+	)
+}
+
+type aiFlag string
+
+const (
+	aiFlagModel  aiFlag = "ai-model"
+	aiFlagPrompt aiFlag = "ai-prompt"
+)
+
+var defaultAiFlags = []flag{
+	{
+		Name:        string(aiFlagModel),
+		Required:    false,
+		Description: "The AI model to use",
+	},
+	{
+		Name:        string(aiFlagPrompt),
+		Required:    false,
+		Description: "The prompt to use for the AI model",
+		Default:     defaultPromptTemplate,
+	},
+}
+
+const (
+	ollamaFlagUrl aiFlag = "url"
+)
+
+func ollamaCmd() *cobra.Command {
+	flags := []flag{
+		{
+			Name:        string(ollamaFlagUrl),
+			Required:    false,
+			Description: "The URl where ollama is accessible",
+			Default:     "http://localhost:11434",
+		},
+	}
+	defaultAiFlags[0].Default = "gemma:2b"
+	flags = append(flags, defaultAiFlags...)
+	cmd := createDefaultCmd(
+		"ollama",
+		"Summarizes using Ollama AI",
+		"Summarizes using Ollama AI.",
+		flags,
+	)
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		s := sourceByCmd(cmd.Parent())
+
+		aiModel, _ := cmd.Flags().GetString(string(aiFlagModel))
+		aiPrompt, _ := cmd.Flags().GetString(string(aiFlagPrompt))
+		url, _ := cmd.Flags().GetString(string(ollamaFlagUrl))
+		p := &provider.Ollama{
+			Common: provider.Common{
+				Model:  aiModel,
+				Prompt: aiPrompt,
+			},
+			Url: url,
+		}
+
+		return summarize(s, p)
+	}
+	return cmd
+}
+
+const (
+	mistralFlagToken aiFlag = "provider-token"
+)
+
+func mistralCmd() *cobra.Command {
+	flags := []flag{
+		{
+			Name:        string(mistralFlagToken),
+			Required:    true,
+			Description: "The API Token for Mistral",
+		},
+	}
+	defaultAiFlags[0].Default = "mistral:7b"
+	flags = append(flags, defaultAiFlags...)
+	cmd := createDefaultCmd(
+		"mistral",
+		"Summarizes using Mistral AI",
+		"Summarizes using Mistral AI.",
+		flags,
+	)
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		s := sourceByCmd(cmd.Parent())
+
+		aiModel, _ := cmd.Flags().GetString(string(aiFlagModel))
+		aiPrompt, _ := cmd.Flags().GetString(string(aiFlagPrompt))
+		apiToken, _ := cmd.Flags().GetString(string(mistralFlagToken))
+		p := &provider.Mistral{
+			Common: provider.Common{
+				Model:  aiModel,
+				Prompt: aiPrompt,
+			},
+			ApiToken: apiToken,
+		}
+
+		return summarize(s, p)
+	}
+	return cmd
+}
+
+const (
+	openaiFlagToken aiFlag = "provider-token"
+)
+
+func openaiCmd() *cobra.Command {
+	flags := []flag{
+		{
+			Name:        string(openaiFlagToken),
+			Required:    true,
+			Description: "The API Token for OpenAI",
+		},
+	}
+	defaultAiFlags[0].Default = "gpt-3.5-turbo"
+	flags = append(flags, defaultAiFlags...)
+	cmd := createDefaultCmd(
+		"openai",
+		"Summarizes using OpenAI AI",
+		"Summarizes using OpenAI AI.",
+		flags,
+	)
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		s := sourceByCmd(cmd.Parent())
+
+		aiModel, _ := cmd.Flags().GetString(string(aiFlagModel))
+		aiPrompt, _ := cmd.Flags().GetString(string(aiFlagPrompt))
+		apiToken, _ := cmd.Flags().GetString(string(openaiFlagToken))
+		p := &provider.OpenAi{
+			Common: provider.Common{
+				Model:  aiModel,
+				Prompt: aiPrompt,
+			},
+			ApiToken: apiToken,
+		}
+
+		return summarize(s, p)
+	}
+	return cmd
+}
+
+func createDefaultCmd(
+	name string,
+	short string,
+	long string,
+	flags []flag,
+) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   name,
+		Short: short,
+		Long:  long,
+	}
+
+	for _, flag := range flags {
+		cmd.PersistentFlags().String(flag.Name, flag.Default, flag.Description)
+		if flag.Required {
+			cmd.MarkPersistentFlagRequired(flag.Name)
+		}
+	}
+
+	return cmd
 }
 
 var defaultPromptTemplate = `
@@ -167,3 +260,37 @@ Here is the discussion:
 <comment>{{ $comment.Body }}</comment>
 {{end}}
 `
+
+func sourceByCmd(cmd *cobra.Command) summaraizer.CommentSource {
+	switch cmd.Name() {
+	case "github":
+		token, _ := cmd.Flags().GetString(string(gitHubFlagSourceToken))
+
+		issue, _ := cmd.Flags().GetString(string(gitHubFlagIssue))
+		githubIssueParts := strings.Split(issue, "/")
+
+		return &source.GitHub{
+			Token:       token,
+			RepoOwner:   githubIssueParts[0],
+			RepoName:    githubIssueParts[1],
+			IssueNumber: githubIssueParts[2],
+		}
+	case "reddit":
+		post, _ := cmd.Flags().GetString(string(redditFlagPost))
+
+		return &source.Reddit{
+			UrlPath: post,
+		}
+	}
+	panic("Unknown source")
+}
+
+func summarize(s summaraizer.CommentSource, p summaraizer.AiProvider) error {
+	summarization, err := summaraizer.Summarize(s, p)
+	if err != nil {
+		return err
+	}
+	fmt.Println(summarization)
+
+	return nil
+}


### PR DESCRIPTION
fixes #18 
fixes #10 

**Decision**
We decided that we go with sub commands for each source and provider plus flags for the respective thing.
Being said, the cli will be called like this:
```bash
summaraizer source provider --flags

# github ollama
summaraizer github ollama --issue=golang/go/66960

# reddit openai
summaraizer reddit openai --post=/r/git/comments/17ka8lk/adding_and_committing_symbolic_link_to_directory/ --provider-token=123
```

Bing said, we have optional and required flags now.
All depending on the source and the (ai) provider.


TODO:
- [ ] Adjust README (Document all providers and sources and how to use them)