### PR TITLE
Gitlab support

### DIFF
--- a/cmd/summaraizer/summaraizer.go
+++ b/cmd/summaraizer/summaraizer.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	rootCmd.AddCommand(githubCmd(), redditCmd())
+	rootCmd.AddCommand(githubCmd(), redditCmd(), gitlabCmd())
 	rootCmd.AddCommand(ollamaCmd(), mistralCmd(), openaiCmd())
 
 	if err := rootCmd.Execute(); err != nil {
@@ -70,6 +70,39 @@ func redditCmd() *cobra.Command {
 	}
 	cmd.Flags().String(flagPost, "", "The Reddit post to summarize. Use the URL path. Everything after reddit.com.")
 	cmd.MarkFlagRequired(flagPost)
+	return cmd
+}
+
+func gitlabCmd() *cobra.Command {
+	flagIssue := "issue"
+	flagToken := "token"
+	flagUrl := "url"
+	var cmd = &cobra.Command{
+		Use:   "gitlab",
+		Short: "Summarizes using GitLab as source",
+		Long:  "Summarizes using GitLab as source",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			issue, _ := cmd.Flags().GetString(flagIssue)
+			githubIssueParts := strings.Split(issue, "/")
+			token, _ := cmd.Flags().GetString(flagToken)
+			url, _ := cmd.Flags().GetString(flagUrl)
+
+			s := &summaraizer.GitLab{
+				Token:       token,
+				RepoOwner:   githubIssueParts[0],
+				RepoName:    githubIssueParts[1],
+				IssueNumber: githubIssueParts[2],
+				Url:         url,
+			}
+			return fetch(s)
+		},
+	}
+	cmd.Flags().String(flagIssue, "", "The GitLab issue to summarize. Use the format owner/repo/issue_number.")
+	cmd.MarkFlagRequired(flagIssue)
+	cmd.Flags().String(flagToken, "", "The GitLab token.")
+	cmd.MarkFlagRequired(flagToken)
+	cmd.Flags().String(flagUrl, "https://gitlab.com", "The URL of the GitLab instance.")
+
 	return cmd
 }
 

--- a/gitlab.go
+++ b/gitlab.go
@@ -1,0 +1,141 @@
+package summaraizer
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// GitLab is a source that fetches comments from a GitLab issue or merge request.
+type GitLab struct {
+	Token       string
+	RepoOwner   string
+	RepoName    string
+	IssueNumber string
+	Url         string // The (base) URL of the GitLab instance.
+}
+
+// Fetch fetches comments from a GitLab issue.
+func (gl *GitLab) Fetch(writer io.Writer) error {
+	return fetchAndEncode(writer, func() (Comments, error) {
+		var comments Comments
+
+		issue := issue{
+			repo: repo{
+				Owner: gl.RepoOwner,
+				Name:  gl.RepoName,
+			},
+			Number: gl.IssueNumber,
+		}
+
+		issueResponse, err := fetchGitLabIssue(gl, issue)
+		if err != nil {
+			return nil, err
+		}
+
+		comments = append(comments, Comment{
+			Author: issueResponse.Author.Username,
+			Body:   issueResponse.Description,
+		})
+
+		issueComments, err := fetchGitLabIssueNotes(gl, issue)
+		if err != nil {
+			return nil, err
+		}
+		for _, issueComments := range *issueComments {
+			comments = append(comments, Comment{
+				Author: issueComments.Author.Username,
+				Body:   issueComments.Body,
+			})
+		}
+
+		return comments, nil
+	})
+}
+
+func fetchGitLabIssue(gl *GitLab, issue issue) (*gitLabIssueResponse, error) {
+	issueURL := fmt.Sprintf(
+		"%s/api/v4/projects/%s/issues/%s",
+		gl.Url,
+		url.QueryEscape(fmt.Sprintf("%s/%s", issue.Owner, issue.Name)),
+		issue.Number,
+	)
+	request := newGitLabRequest("GET", issueURL, gl.Token)
+	resp, err := http.DefaultClient.Do(&request)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var issueResponse gitLabIssueResponse
+	err = json.Unmarshal(body, &issueResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &issueResponse, nil
+}
+
+func fetchGitLabIssueNotes(gl *GitLab, issue issue) (*gitLabIssueNotesResponse, error) {
+	commentsURL := fmt.Sprintf(
+		"%s/api/v4/projects/%s/issues/%s/notes?per_page=100",
+		gl.Url,
+		url.QueryEscape(fmt.Sprintf("%s/%s", issue.Owner, issue.Name)),
+		issue.Number,
+	)
+	request := newGitLabRequest("GET", commentsURL, gl.Token)
+	resp, err := http.DefaultClient.Do(&request)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var commentsResponse gitLabIssueNotesResponse
+	err = json.Unmarshal(body, &commentsResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &commentsResponse, nil
+}
+
+func newGitLabRequest(method, url string, token string) http.Request {
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		panic(err)
+	}
+	addGitLabHeaders(req, token)
+	return *req
+}
+
+func addGitLabHeaders(req *http.Request, token string) {
+	req.Header.Add("PRIVATE-TOKEN", token)
+}
+
+type gitLabIssueResponse struct {
+	Description string               `json:"description"`
+	Author      gitLabAuthorResponse `json:"author"`
+}
+
+type gitLabAuthorResponse struct {
+	Username string `json:"username"`
+}
+
+type gitLabIssueNotesResponse = []gitLabIssueNoteResponse
+
+type gitLabIssueNoteResponse struct {
+	Body   string               `json:"body"`
+	Author gitLabAuthorResponse `json:"author"`
+}


### PR DESCRIPTION
fixes #15 
Build on top of #23.
Needs to be rebased or smth if its got merged. 

Actually, it adds support for issues, not sure if they work for merge requests yet. 😅 

```bash
go run cmd/summaraizer/summaraizer.go gitlab --issue infosec/policies/155 --token [TOKEN] --url https://gitlab.example.org 
```